### PR TITLE
Use a Git submodule for external dependencies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "midi_processor"]
+	path = midi_processor
+	url = https://github.com/jason9693/midi-neural-processor.git

--- a/README.md
+++ b/README.md
@@ -35,10 +35,8 @@
 
 ## Repository Setting
 ```bash
-$ git clone https://github.com/jason9693/MusicTransformer-tensorflow2.0.git
+$ git clone --recurse-submodules https://github.com/jason9693/MusicTransformer-tensorflow2.0.git
 $ cd MusicTransformer-tensorflow2.0
-$ git clone https://github.com/jason9693/midi-neural-processor.git
-$ mv midi-neural-processor midi_processor
 ```
 
 


### PR DESCRIPTION
Removes the need to clone twice.