### PR TITLE
Actually use `pickle_dir` command-line argument

### DIFF
--- a/train.py
+++ b/train.py
@@ -41,7 +41,7 @@ num_layer = args.num_layers
 
 
 # load data
-dataset = Data('dataset/processed')
+dataset = Data(pickle_dir)
 print(dataset)
 
 


### PR DESCRIPTION
Previously, the directory was hard-coded and the command-line parameter was unreferenced.