### PR TITLE
Raise an exception if the pickle file directory is empty

### DIFF
--- a/data.py
+++ b/data.py
@@ -9,6 +9,10 @@ import params as par
 class Data:
     def __init__(self, dir_path):
         self.files = list(utils.find_files_by_extensions(dir_path, ['.pickle']))
+
+        if len(self.files) == 0:
+            raise ValueError("No pickle files found to analyze.")
+
         self.file_dict = {
             'train': self.files[:int(len(self.files) * 0.8)],
             'eval': self.files[int(len(self.files) * 0.8): int(len(self.files) * 0.9)],


### PR DESCRIPTION
Currently, the processing just ends very quickly, which can be confusing. More than likely, the user was trying to enter some files to process.