### PR TITLE
Refactor to `@tf.function`

### DIFF
--- a/custom/callback.py
+++ b/custom/callback.py
@@ -21,6 +21,7 @@ class TransformerLoss(keras.losses.SparseCategoricalCrossentropy):
         self.debug = debug
         pass
 
+    @tf.function
     def call(self, y_true, y_pred):
         y_true = tf.cast(y_true, tf.int32)
         mask = tf.math.logical_not(tf.math.equal(y_true, par.pad_token))

--- a/custom/layers.py
+++ b/custom/layers.py
@@ -239,6 +239,7 @@ class RelativeGlobalAttention(keras.layers.Layer):
         return e
 
     @staticmethod
+    @tf.function
     def _qe_masking(qe):
         mask = tf.sequence_mask(
             tf.range(qe.shape[-1] -1, qe.shape[-1] - qe.shape[-2] -1, -1), qe.shape[-1])
@@ -248,6 +249,7 @@ class RelativeGlobalAttention(keras.layers.Layer):
 
         return mask * qe
 
+    @tf.function
     def _skewing(self, tensor: tf.Tensor):
         padded = tf.pad(tensor, [[0, 0], [0,0], [0, 0], [1, 0]])
         reshaped = tf.reshape(padded, shape=[-1, padded.shape[1], padded.shape[-1], padded.shape[-2]])

--- a/model.py
+++ b/model.py
@@ -8,6 +8,7 @@ import tensorflow_probability as tfp
 import random
 import utils
 from progress.bar import Bar
+from tensorflow import function
 tf.executing_eagerly()
 
 
@@ -38,6 +39,7 @@ class MusicTransformer(keras.Model):
         if loader_path is not None:
             self.load_ckpt_file(loader_path)
 
+    @function
     def call(self, inputs, targets, training=None, eval=None, src_mask=None, trg_mask=None, lookup_mask=None):
         encoder, weight_encoder = self.Encoder(inputs, training=training, mask=src_mask)
         decoder, weights = self.Decoder(
@@ -81,6 +83,7 @@ class MusicTransformer(keras.Model):
         return [loss.numpy()]+result_metric
 
     # @tf.function
+    @function
     def __dist_train_step(self, inp, inp_tar, out_tar, enc_mask, tar_mask, lookup_mask, training):
         return self._distribution_strategy.experimental_run_v2(
             self.__train_step, args=(inp, inp_tar, out_tar, enc_mask, tar_mask, lookup_mask, training))
@@ -283,6 +286,7 @@ class MusicTransformerDecoder(keras.Model):
         if loader_path is not None:
             self.load_ckpt_file(loader_path)
 
+    @function
     def call(self, inputs, training=None, eval=None, lookup_mask=None):
         decoder, w = self.Decoder(inputs, training=training, mask=lookup_mask)
         fc = self.fc(decoder)
@@ -322,6 +326,7 @@ class MusicTransformerDecoder(keras.Model):
         return [loss.numpy()]+result_metric
 
     # @tf.function
+    @function
     def __dist_train_step(self, inp_tar, out_tar, lookup_mask, training):
         return self._distribution_strategy.experimental_run_v2(
             self.__train_step, args=(inp_tar, out_tar, lookup_mask, training))


### PR DESCRIPTION
We converted several eager execution function to hybrid execution as part of an assessment of our refactoring tool. The transformations produced were completely automated. We have some preliminary evidence that this improves the run-time performance:

Test | Python version | TensorFlow version | Epochs | Before accuracy | After accuracy | Before loss | After loss | Before elapsed time (s) | After elapsed time (s) | Speedup
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
MusicTransformer-tensorflow2.0/train.py | 3.10.0 | 2.9.3 | 5 | 0.0233113606 | 0.02381204049 | 4.956358294 | 4.923633542 | 1330.180665 | 919.3014389 | 1.446947224

The above analysis was repeated five times for each program version (before and after the refactoring) and the values were averaged. The increased speedup is ~1.45 with seemingly negligible loss of accuracy. We would appreciate any feedback you may have to help us as assess our refactoring approach. Thank you for your time!